### PR TITLE
Adding the `PhantomJS` for testing http & websocket procols

### DIFF
--- a/fetch-ledger-develop-image/Dockerfile
+++ b/fetch-ledger-develop-image/Dockerfile
@@ -70,6 +70,8 @@ RUN bash --login -c "\
     echo NUMBER_OF_CPU_CORES: \$NUMBER_OF_CPU_CORES && \
     sudo ./b2 -j\$NUMBER_OF_CPU_CORES install --with=all"
 
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
 RUN bash --login -c "\
     cd /src && \
     git clone https://github.com/acaudwell/Gource.git && \


### PR DESCRIPTION
This change brings the `PhantomJS` application in to our docker develop image in order to enable using JavaScript (can be embeded in html document) for excercising our http and webscoket servers.