### PR TITLE
Add clang-format and clang-tidy

### DIFF
--- a/fetch-ledger-develop-image/Dockerfile
+++ b/fetch-ledger-develop-image/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && \
     apt-get install -y gcc && \
     apt-get install -y g++ && \
     apt-get install -y gdb && \
+    apt-get install -y clang-tidy && \
+    apt-get install -y clang-format && \
     apt-get install -y sudo
 
 # This adds the `default` user in to sudoers with full privileges:

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -15,7 +15,7 @@ SCRIPTS_DIR=${0%/*}
 docker_run_callback() {
     local DOCKER_PARAMS="$1"
     local EXECUTABLE_PARAMS="$2"
-    local COMMAND="docker run -i $USE_TTY -w $WORKDIR --rm  $DOCKER_PARAMS -v $(pwd):$WORKDIR $DOCKER_IMAGE_TAG $EXECUTABLE_PARAMS"
+    local COMMAND="docker run -i $USE_TTY -w $WORKDIR --rm  $DOCKER_PARAMS -v $(pwd):$WORKDIR:cached $DOCKER_IMAGE_TAG $EXECUTABLE_PARAMS"
     echo $COMMAND
     $COMMAND
 }


### PR DESCRIPTION
Update the development docker image to include clang-format and clang-tidy.

Also switched to cached volume mounting to speed up execution under MacOS