### PR TITLE
Autoformatting Python and CMake scripts

### DIFF
--- a/fetch-ledger-develop-image/Dockerfile
+++ b/fetch-ledger-develop-image/Dockerfile
@@ -58,10 +58,9 @@ RUN OPENSSL_SRC_DIR="/home/default/openssl" && \
     rm -rf "${OPENSSL_SRC_DIR}"
 
 # Required for integration tests
-RUN apt-get install -y python3-pip && \
-         pip3 install PyYAML && \
-         pip3 install -U fetchai-ledger-api && \
-         pip3 install -i https://test.pypi.org/simple/ fetchai-netutils==0.0.1
+RUN pip3 install PyYAML && \
+    pip3 install -U fetchai-ledger-api && \
+    pip3 install -i https://test.pypi.org/simple/ fetchai-netutils==0.0.1
 
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib
 

--- a/fetch-ledger-develop-image/Dockerfile
+++ b/fetch-ledger-develop-image/Dockerfile
@@ -57,12 +57,11 @@ RUN OPENSSL_SRC_DIR="/home/default/openssl" && \
     cd "${ORIG_DIR}" && \
     rm -rf "${OPENSSL_SRC_DIR}"
 
-# Required for integration tests
+# Required for integration tests/style checks
 RUN pip3 install PyYAML && \
     pip3 install -U fetchai-ledger-api && \
-    pip3 install -i https://test.pypi.org/simple/ fetchai-netutils==0.0.1
-
-RUN pip3 install autopep8 cmake_format
+    pip3 install -i https://test.pypi.org/simple/ fetchai-netutils==0.0.1 && \
+    pip3 install autopep8 cmake_format
 
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib
 

--- a/fetch-ledger-develop-image/Dockerfile
+++ b/fetch-ledger-develop-image/Dockerfile
@@ -62,6 +62,8 @@ RUN pip3 install PyYAML && \
     pip3 install -U fetchai-ledger-api && \
     pip3 install -i https://test.pypi.org/simple/ fetchai-netutils==0.0.1
 
+RUN pip3 install autopep8 cmake_format
+
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib
 
 USER default


### PR DESCRIPTION
This is a dependency for fetch-ledger's PR 955 for autoformatting Python, as well as a (forthcoming) analogous change for CMake files. I'm clumping them together to spare us having to bump the Docker image tag twice.

I also removed a duplicate `apt-get install` instruction.